### PR TITLE
Changed how the apollo client is being created with uri

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -9,9 +9,8 @@ import Nav from "../Nav/Nav"
 import './App.css';
 import EventForm from '../EventForm/EventForm'
 
-
 const client = new ApolloClient({
-  uri: `${process.env.REACT_APP_BASE_URL}/graphql?test=1`,
+  uri: process.env.REACT_APP_BASE_URL,
   cache: new InMemoryCache()
 });
 


### PR DESCRIPTION
Needed to update the ApolloClient uri to not be an interpolated env var.  Heroku was interpolating this uri into a string with the heroku app uri.

## Type of Changes:
- [x] Bug fix
- [ ] Refactor
- [ ] New feature


## How was this tested:
Chrome Dev Tools