### PR TITLE
Refactor/profile view

### DIFF
--- a/src/Components/EventModal/EventModal.js
+++ b/src/Components/EventModal/EventModal.js
@@ -93,7 +93,7 @@ function EventModal({userId, eventId, isRsvpd, visible, handleClose}) {
           :
             <button onClick={(e) => createRsvp(e)}> RSVP!</button>
         }
-          <Link to='/profile'>
+          <Link to={{pathname:'/profile', state:{hostId: data.event.creator.id}}}>
             <button>View Family Profile</button>
           </Link>
           <div className='event-modal-map'>

--- a/src/Components/EventModal/EventModal.js
+++ b/src/Components/EventModal/EventModal.js
@@ -1,14 +1,17 @@
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
 import './EventModal.css'
 import Modal from 'react-modal';
 import ReactDOM from 'react-dom';
 import { Link } from 'react-router-dom';
 import { useQuery, useMutation } from "@apollo/client";
 import { GET_EVENT_BY_ID, USER_RSVP_TO_EVENT, USER_DELETE_RSVP } from "../../queries";
+import UserContext from "../../Context/UserContext"
 
 Modal.setAppElement('#root');
 
 function EventModal({userId, eventId, isRsvpd, visible, handleClose}) {
+
+  const user = useContext(UserContext)
 
   const {loading, error, data} = useQuery(GET_EVENT_BY_ID, {
     variables: {"id": parseInt(eventId)}
@@ -62,6 +65,21 @@ function EventModal({userId, eventId, isRsvpd, visible, handleClose}) {
     },
   };
 
+  const renderButtons = () => {
+    return (
+      <>
+        {rsvpd ?
+          <button onClick={(e) => deleteRsvp(e)}> Cancel RSVP</button>
+        :
+          <button onClick={(e) => createRsvp(e)}> RSVP!</button>
+        }
+        <Link to={{pathname:'/profile', state:{hostId: data.event.creator.id}}} onClick={closeModal}>
+          <button>View Family Profile</button>
+        </Link> 
+      </>
+    )
+  }
+
   if(loading) return "Loading..."
   if(error) return `Error! ${error.message}`
 
@@ -88,14 +106,8 @@ function EventModal({userId, eventId, isRsvpd, visible, handleClose}) {
           <h1>{data.event.creator.userName}</h1>
           <img className='event-img' src={data.event.creator.image}/>
           <br/>
-          {rsvpd ?
-            <button onClick={(e) => deleteRsvp(e)}> Cancel RSVP</button>
-          :
-            <button onClick={(e) => createRsvp(e)}> RSVP!</button>
-        }
-          <Link to={{pathname:'/profile', state:{hostId: data.event.creator.id}}} onClick={closeModal}>
-            <button>View Family Profile</button>
-          </Link>
+          {user.id !== data.event.creator.id && renderButtons()
+          }
           <div className='event-modal-map'>
             <h1>Map</h1>
           </div>

--- a/src/Components/EventModal/EventModal.js
+++ b/src/Components/EventModal/EventModal.js
@@ -69,7 +69,7 @@ function EventModal({userId, eventId, isRsvpd, visible, handleClose}) {
     <>
     <button onClick={openModal}>Open Modal</button>
     <Modal id='event'
-    className='event-modal'
+     className='event-modal'
      isOpen={modalIsOpen}
      onRequestClose={closeModal}
      style={customStyles}>
@@ -93,7 +93,7 @@ function EventModal({userId, eventId, isRsvpd, visible, handleClose}) {
           :
             <button onClick={(e) => createRsvp(e)}> RSVP!</button>
         }
-          <Link to={{pathname:'/profile', state:{hostId: data.event.creator.id}}}>
+          <Link to={{pathname:'/profile', state:{hostId: data.event.creator.id}}} onClick={closeModal}>
             <button>View Family Profile</button>
           </Link>
           <div className='event-modal-map'>

--- a/src/Components/UserProfile/UserProfile.js
+++ b/src/Components/UserProfile/UserProfile.js
@@ -1,6 +1,6 @@
 import React, {useState, useContext} from "react";
 import { useLocation } from "react-router";
-import { useQuery } from "@apollo/client";
+import { useLazyQuery } from "@apollo/client";
 import { GET_USER_BY_ID } from "../../queries";
 import "./UserProfile.css";
 import EventModal from '../EventModal/EventModal'
@@ -8,11 +8,26 @@ import Events from "../Events/Events"
 import UserContext from '../../Context/UserContext';
 
 const UserProfile = () => {
-  const {state: { hostId }} = useLocation()
-  const user = useContext(UserContext)
-  
   const [modalVisible, setModalVisible] = useState(false)
   const [eventId, setEventId] = useState()
+  const { state } = useLocation()
+
+  let user = useContext(UserContext)
+  
+  const [queryHost, {loading, error, data}] = useLazyQuery(GET_USER_BY_ID, {
+    variables: {"id": state.hostId}
+  })
+
+
+  if(loading) return "Loading..."
+  if(error) return `Error! ${error.message}`
+
+  if(state && !data){
+    queryHost()
+  } else if (state && data) {
+    user = data.user
+  }
+
   const handleClick = (e) => {
     const {id} = e.target
     setEventId(id)
@@ -58,7 +73,7 @@ const UserProfile = () => {
       </section>
 
       <section className="right-container">
-        <Events events={user.rsvpdEvents} eventTitle={"Event you're Attending"} type={"card"} handleClick={handleClick} />
+        {!state && <Events events={user.rsvpdEvents} eventTitle={"Event you're Attending"} type={"card"} handleClick={handleClick} />}
         <Events events={user.userEvents} eventTitle={"Event you've Created"} type={"card"} handleClick={handleClick} />
 
       </section>

--- a/src/Components/UserProfile/UserProfile.js
+++ b/src/Components/UserProfile/UserProfile.js
@@ -1,4 +1,5 @@
 import React, {useState, useContext} from "react";
+import { useLocation } from "react-router";
 import { useQuery } from "@apollo/client";
 import { GET_USER_BY_ID } from "../../queries";
 import "./UserProfile.css";
@@ -6,11 +7,8 @@ import EventModal from '../EventModal/EventModal'
 import Events from "../Events/Events"
 import UserContext from '../../Context/UserContext';
 
-// SETUP AS A FAMILY VIEW FROM THE EVENT DETAILS PAGE
-// Can use a query hook for data for DRY code or just pass as props
-
 const UserProfile = () => {
-
+  const {state: { hostId }} = useLocation()
   const user = useContext(UserContext)
   
   const [modalVisible, setModalVisible] = useState(false)

--- a/src/Components/UserProfile/UserProfile.js
+++ b/src/Components/UserProfile/UserProfile.js
@@ -10,18 +10,25 @@ import UserContext from '../../Context/UserContext';
 const UserProfile = () => {
   const [modalVisible, setModalVisible] = useState(false)
   const [eventId, setEventId] = useState()
+  // If you click on a link with state, it will be defined here using useLocation hook.
+  // This allows us to pass a hostId to the User Profile from the Event Modal.
   const { state } = useLocation()
 
   let user = useContext(UserContext)
+  let title = state ? "They" : "You've"
   
+  //useLazyQuery allows us to create a function that can be invoked when we want it to.
+  // Here we are using queryHost function only if state from above exists.
+  // This means we want to query the host by id, instead of using our signed in user.
   const [queryHost, {loading, error, data}] = useLazyQuery(GET_USER_BY_ID, {
-    variables: {"id": state.hostId}
+    variables: {"id": state?.hostId}
   })
-
 
   if(loading) return "Loading..."
   if(error) return `Error! ${error.message}`
 
+  // If state exists and data is undefined, call queryHost function to get host.
+  // If state is undefined, then hostId isn't present, and we render the current user profile.
   if(state && !data){
     queryHost()
   } else if (state && data) {
@@ -74,7 +81,7 @@ const UserProfile = () => {
 
       <section className="right-container">
         {!state && <Events events={user.rsvpdEvents} eventTitle={"Event you're Attending"} type={"card"} handleClick={handleClick} />}
-        <Events events={user.userEvents} eventTitle={"Event you've Created"} type={"card"} handleClick={handleClick} />
+        <Events events={user.userEvents} eventTitle={`Event ${title} Created`} type={"card"} handleClick={handleClick} />
 
       </section>
     </div>


### PR DESCRIPTION
## Summary:
Updated modal to conditionally render show family profile and rsvp button depending on if the event belongs to the current signed in user.
The profile page conditionally renders view if it is the users profile or a hosts profile-
If the profile being viewed is a hosts/other family profile then the user does not see the events that the user RSVP'd to

## Type of Changes:
- [ ] Bug fix
- [x] Refactor
- [x] New feature


## How was this tested:
chrome dev tools

## What are the relevant tickets:
closes #14 
closes #49 